### PR TITLE
Fix tests and reuse winston log message builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "0.6"
+  - "0.8"
+  - "0.9"
+  - "0.10"
+before_script:
+  - npm install -g vows

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Anton Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/examples/container.js
+++ b/examples/container.js
@@ -1,0 +1,25 @@
+var winston = require('winston');
+
+// load transport, but do not attach it yet
+var PosixSyslog = require('../lib/winston-posix-syslog').PosixSyslog;
+
+// 
+winston.loggers.add('node-posix-logger', {
+    console: {
+        level: 'silly',
+        colorize: 'true',
+        label: 'node-posix-logger'
+    },
+    PosixSyslog : {
+    	level: 'silly',
+    	colorize: 'true',
+    	label: 'node-posix-logger',
+        identity: 'node-logger'
+    }
+});
+
+var logger = winston.loggers.get('node-posix-logger');
+
+logger.debug('debug message');
+logger.info('info message.');
+logger.error('error message');

--- a/examples/container.js
+++ b/examples/container.js
@@ -5,17 +5,17 @@ var PosixSyslog = require('../lib/winston-posix-syslog').PosixSyslog;
 
 // 
 winston.loggers.add('node-posix-logger', {
-    console: {
-        level: 'silly',
-        colorize: 'true',
-        label: 'node-posix-logger'
-    },
-    PosixSyslog : {
-    	level: 'silly',
-    	colorize: 'true',
-    	label: 'node-posix-logger',
-        identity: 'node-logger'
-    }
+  console: {
+    level: 'silly',
+    colorize: 'true',
+    label: 'node-posix-logger'
+  },
+  PosixSyslog: {
+    level: 'silly',
+    colorize: 'true',
+    label: 'node-posix-logger',
+    identity: 'node-logger'
+  }
 });
 
 var logger = winston.loggers.get('node-posix-logger');

--- a/lib/winston-posix-syslog.js
+++ b/lib/winston-posix-syslog.js
@@ -67,7 +67,7 @@ PosixSyslog.prototype.log = function (level, msg, meta, callback) {
       output;
 
   output = common.log({
-    colorize:    this.colorize,
+    colorize:    false, // do not allow colors in syslogs
     json:        this.json,
     level:       level,
     message:     msg,

--- a/lib/winston-posix-syslog.js
+++ b/lib/winston-posix-syslog.js
@@ -28,8 +28,8 @@ var PosixSyslog = winston.transports.PosixSyslog = function (options) {
   winston.Transport.call(this, options);
   options = options || {};
 
-  this.json = options.json || false;
-  this.colorize = options.colorize || false;
+  this.json = false;
+  this.colorize = false;
   this.prettyPrint = options.prettyPrint || false;
   this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
   this.label = options.label || null;

--- a/lib/winston-posix-syslog.js
+++ b/lib/winston-posix-syslog.js
@@ -1,7 +1,7 @@
-var util = require('util')
-  , winston = require('winston')
-  , posix = require('posix')
-  ;
+var util = require('util'),
+    winston = require('winston'),
+    posix = require('posix'),
+    common = require('winston/lib/winston/common');
 
 var syslogLevels = {
   debug: 'debug',
@@ -25,8 +25,22 @@ var getMasks = function() {
 }
 
 var PosixSyslog = winston.transports.PosixSyslog = function (options) {
+  winston.Transport.call(this, options);
   options = options || {};
 
+  this.json        = options.json        || false;
+  this.colorize    = options.colorize    || false;
+  this.prettyPrint = options.prettyPrint || false;
+  this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.label       = options.label       || null;
+
+  if (this.json) {
+    this.stringify = options.stringify || function (obj) {
+      return JSON.stringify(obj, null, 2);
+    };
+  }
+
+  // syslog specific
   this.identity = options.identity || process.title;
   this.facility = options.facility || 'local0';
 
@@ -39,26 +53,37 @@ var PosixSyslog = winston.transports.PosixSyslog = function (options) {
   }
 };
 
-var buildMessage = function(msg, meta) {
-  if (meta) {
-    return util.format("%s: %s", msg, JSON.stringify(meta));
-  }
-
-  return msg;
-};
-
 util.inherits(PosixSyslog, winston.Transport);
 
 PosixSyslog.prototype.name = 'posixSyslog';
 
 PosixSyslog.prototype.log = function (level, msg, meta, callback) {
-  var self = this;
+
+  if (this.silent) {
+    return callback(null, true);
+  }
+
+  var self = this,
+      output;
+
+  output = common.log({
+    colorize:    this.colorize,
+    json:        this.json,
+    level:       level,
+    message:     msg,
+    meta:        meta,
+    stringify:   this.stringify,
+    timestamp:   this.timestamp,
+    prettyPrint: this.prettyPrint,
+    raw:         this.raw,
+    label:       this.label
+  });
 
   // We ignore any incompatible levels
   if (level in syslogLevels) {
     posix.openlog(self.identity, self.openLogOptions, self.facility);
     posix.setlogmask(getMasks());
-    posix.syslog(syslogLevels[level], buildMessage(msg, meta));
+    posix.syslog(syslogLevels[level], output);
     posix.closelog();
     self.emit('logged');
   }

--- a/lib/winston-posix-syslog.js
+++ b/lib/winston-posix-syslog.js
@@ -1,7 +1,7 @@
 var util = require('util'),
-    winston = require('winston'),
-    posix = require('posix'),
-    common = require('winston/lib/winston/common');
+  winston = require('winston'),
+  posix = require('posix'),
+  common = require('winston/lib/winston/common');
 
 var syslogLevels = {
   debug: 'debug',
@@ -13,7 +13,7 @@ var syslogLevels = {
   alert: 'alert'
 };
 
-var getMasks = function() {
+var getMasks = function () {
   var masks = {};
 
   for (var level in syslogLevels) {
@@ -28,11 +28,11 @@ var PosixSyslog = winston.transports.PosixSyslog = function (options) {
   winston.Transport.call(this, options);
   options = options || {};
 
-  this.json        = options.json        || false;
-  this.colorize    = options.colorize    || false;
+  this.json = options.json || false;
+  this.colorize = options.colorize || false;
   this.prettyPrint = options.prettyPrint || false;
-  this.timestamp   = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
-  this.label       = options.label       || null;
+  this.timestamp = typeof options.timestamp !== 'undefined' ? options.timestamp : false;
+  this.label = options.label || null;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -64,19 +64,19 @@ PosixSyslog.prototype.log = function (level, msg, meta, callback) {
   }
 
   var self = this,
-      output;
+    output;
 
   output = common.log({
-    colorize:    false, // do not allow colors in syslogs
-    json:        this.json,
-    level:       level,
-    message:     msg,
-    meta:        meta,
-    stringify:   this.stringify,
-    timestamp:   this.timestamp,
+    colorize: false, // do not allow colors in syslogs
+    json: this.json,
+    level: level,
+    message: msg,
+    meta: meta,
+    stringify: this.stringify,
+    timestamp: this.timestamp,
     prettyPrint: this.prettyPrint,
-    raw:         this.raw,
-    label:       this.label
+    raw: this.raw,
+    label: this.label
   });
 
   // We ignore any incompatible levels

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   },
   "main": "./lib/winston-posix-syslog",
   "engines": {
-    "node": ">= 0.4.0"
+    "node": ">= 0.8.0"
+  },
+  "scripts": {
+    "test": "vows test/* --spec"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   },
   "main": "./lib/winston-posix-syslog",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.6.0"
   },
   "scripts": {
-    "test": "vows test/* --spec"
+    "test": "vows test/* --spec --isolate"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
     "name": "Anton Nguyen",
     "email": "anton@freshbooks.com"
   },
+  "contributors": [
+    {
+      "name": "Christoph Hartmann",
+      "email": "chris@lollyrock.com"
+    }
+  ],
   "preferGlobal": false,
   "dependencies": {
     "util": "0.4.9",

--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -1,12 +1,20 @@
-var path = require('path')
-  , vows = require('vows')
-  , assert = require('assert')
-  , winston = require('winston')
-  , helpers = require('winston/test/helpers')
-  , PosixSyslog = require('../lib/winston-posix-syslog').PosixSyslog
-  , npmTransport = new (PosixSyslog)()
-  , posixSyslogTransport = new (PosixSyslog)({ levels: winston.config.syslog.levels })
-  ;
+/*
+ * syslog-test.js: Tests for instances of the PosixSyslog transport
+ *
+ * (C) 2013 Christoph Hartmann
+ * MIT LICENSE
+ *
+ */
+
+var path = require('path'),
+    vows = require('vows'),
+    assert = require('assert'),
+    winston = require('winston'),
+    helpers = require('winston/test/helpers');
+
+var PosixSyslog = require('../lib/winston-posix-syslog').PosixSyslog,
+    npmTransport = new (winston.transports.PosixSyslog)(),
+    syslogTransport = new (winston.transports.PosixSyslog)({ levels: winston.config.syslog.levels })
 
 var assertPosixSyslog = function(transport) {
   assert.instanceOf(transport, PosixSyslog);
@@ -14,11 +22,6 @@ var assertPosixSyslog = function(transport) {
 };
 
 vows.describe('winston-posix-syslog').addBatch({
-  "Instantiation of the PosixSyslog Transport": {
-    "With no options should not fail": function() {
-      winston.add(PosixSyslog);
-    }
-  },
   "An instance of the PosixSyslog Transport": {
     "with npm levels": {
       "should have the proper methods defined": function () {
@@ -31,9 +34,9 @@ vows.describe('winston-posix-syslog').addBatch({
     },
     "with syslog levels": {
       "should have the proper methods defined": function () {
-        assertPosixSyslog(posixSyslogTransport);
+        assertPosixSyslog(syslogTransport);
       },
-      "the log() method": helpers.testSyslogLevels(posixSyslogTransport, "should respond with true", function (ign, err, logged) {
+      "the log() method": helpers.testSyslogLevels(syslogTransport, "should respond with true", function (ign, err, logged) {
         assert.isNull(err);
         assert.isTrue(logged);
       })

--- a/test/syslog-test.js
+++ b/test/syslog-test.js
@@ -7,18 +7,20 @@
  */
 
 var path = require('path'),
-    vows = require('vows'),
-    assert = require('assert'),
-    winston = require('winston'),
-    helpers = require('winston/test/helpers');
+  vows = require('vows'),
+  assert = require('assert'),
+  winston = require('winston'),
+  helpers = require('winston/test/helpers');
 
 var PosixSyslog = require('../lib/winston-posix-syslog').PosixSyslog,
-    npmTransport = new (winston.transports.PosixSyslog)(),
-    syslogTransport = new (winston.transports.PosixSyslog)({ levels: winston.config.syslog.levels })
+  npmTransport = new(winston.transports.PosixSyslog)(),
+  syslogTransport = new(winston.transports.PosixSyslog)({
+    levels: winston.config.syslog.levels
+  })
 
-var assertPosixSyslog = function(transport) {
-  assert.instanceOf(transport, PosixSyslog);
-  assert.isFunction(transport.log);
+  var assertPosixSyslog = function (transport) {
+    assert.instanceOf(transport, PosixSyslog);
+    assert.isFunction(transport.log);
 };
 
 vows.describe('winston-posix-syslog').addBatch({


### PR DESCRIPTION
- fix the vows tests with the current winston release
- reuse message builder from `winston/lib/winston/common`
- add config for travis ci
- add example
- add license
