### PR TITLE
Be more relaxed about dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "preferGlobal": false,
   "dependencies": {
-    "util": "0.4.9",
-    "posix": "1.0.0",
+    "util": "0.4.x",
+    "posix": "1.0.x",
     "winston": "0.7.x"
   },
   "devDependencies": {


### PR DESCRIPTION
posix 1.0.3 contains bugfix relevant to this module (https://github.com/melor/node-posix/issues/20)

Is there any reason why should posix and util depend on exact version?

And btw, thanks for the package, it's exactly what I need!
