### PR TITLE
buildMessage should only add metadata if there are metadata keys

### DIFF
--- a/lib/winston-posix-syslog.js
+++ b/lib/winston-posix-syslog.js
@@ -40,7 +40,7 @@ var PosixSyslog = winston.transports.PosixSyslog = function (options) {
 };
 
 var buildMessage = function(msg, meta) {
-  if (meta) {
+  if (typeof(meta) == 'object' && meta && Object.keys(meta).length) {
     return util.format("%s: %s", msg, JSON.stringify(meta));
   }
 


### PR DESCRIPTION
This is a fix for issue #4
