### PR TITLE
Support setting transport-specific logging level

### DIFF
--- a/lib/winston-posix-syslog.js
+++ b/lib/winston-posix-syslog.js
@@ -29,6 +29,7 @@ var PosixSyslog = winston.transports.PosixSyslog = function (options) {
 
   this.identity = options.identity || process.title;
   this.facility = options.facility || 'local0';
+  this.level = options.level || false;
 
   this.openLogOptions = {
     cons: options.cons || true,


### PR DESCRIPTION
This is used by Winston when deciding whether to send a message to the transport or not. If not set, it is using the global level.
